### PR TITLE
Return GDS error code in error object

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,17 @@
+module.exports = {
+    GDSError: GDSError
+};
+
+function GDSError(gdsObject) {
+    if (Error.captureStackTrace) {
+        Error.captureStackTrace(this, this.constructor);
+    } else {
+        this.stack = (new Error()).stack;
+    }
+
+    this.message = gdsObject && gdsObject.message || '';
+    this.code = gdsObject && gdsObject.status && gdsObject.status.length > 0 && gdsObject.status[0].gdscode || -1;
+}
+
+GDSError.prototype = Object.create(Error.prototype);
+GDSError.prototype.name = 'GDSError';

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -3,14 +3,14 @@ module.exports = {
 };
 
 function GDSError(gdsObject) {
+    this.message = gdsObject && gdsObject.message || '';
+    this.code = gdsObject && gdsObject.status && gdsObject.status.length > 0 && gdsObject.status[0].gdscode || -1;
+
     if (Error.captureStackTrace) {
-        Error.captureStackTrace(this, this.constructor);
+        Error.captureStackTrace(this, GDSError);
     } else {
         this.stack = (new Error()).stack;
     }
-
-    this.message = gdsObject && gdsObject.message || '';
-    this.code = gdsObject && gdsObject.status && gdsObject.status.length > 0 && gdsObject.status[0].gdscode || -1;
 }
 
 GDSError.prototype = Object.create(Error.prototype);

--- a/lib/index.js
+++ b/lib/index.js
@@ -590,30 +590,34 @@ const
 /*************************************/
 /* Transaction parameter block stuff */
 /*************************************/
-const
-    isc_tpb_version1                =  1,
-    isc_tpb_version3                =  3,
-    isc_tpb_consistency             =  1,
-    isc_tpb_concurrency             =  2,
-    isc_tpb_shared                  =  3, // < FB21
-    isc_tpb_protected               =  4, // < FB21
-    isc_tpb_exclusive               =  5, // < FB21
-    isc_tpb_wait                    =  6,
-    isc_tpb_nowait                  =  7,
-    isc_tpb_read                    =  8,
-    isc_tpb_write                   =  9,
-    isc_tpb_lock_read               =  10,
-    isc_tpb_lock_write              =  11,
-    isc_tpb_verb_time               =  12,
-    isc_tpb_commit_time             =  13,
-    isc_tpb_ignore_limbo            =  14,
-    isc_tpb_read_committed          =  15,
-    isc_tpb_autocommit              =  16,
-    isc_tpb_rec_version             =  17,
-    isc_tpb_no_rec_version          =  18,
-    isc_tpb_restart_requests        =  19,
-    isc_tpb_no_auto_undo            =  20,
-    isc_tpb_lock_timeout            =  21; // >= FB20
+const ISC_TPB = {
+    version1: 1,
+    version3: 3,
+    consistency: 1,
+    concurrency: 2,
+    shared: 3,  // < FB21
+    protected: 4,  // < FB21
+    exclusive: 5,  // < FB21
+    wait: 6,
+    nowait: 7,
+    read: 8,
+    write: 9,
+    lock_read: 10,
+    lock_write: 11,
+    verb_time: 12,
+    commit_time: 13,
+    ignore_limbo: 14,
+    read_committed: 15,
+    autocommit: 16,
+    rec_version: 17,
+    no_rec_version: 18,
+    restart_requests: 19,
+    no_auto_undo: 20,
+    // >= FB20
+    lock_timeout: 21
+};
+Object.freeze(ISC_TPB);
+exports.ISC_TPB = ISC_TPB;
 
 /****************************/
 /* Common, structural codes */
@@ -738,11 +742,11 @@ const
             isc_info_sql_describe_end];
 
 const
-    ISOLATION_READ_UNCOMMITTED          = [isc_tpb_version3, isc_tpb_write, isc_tpb_wait, isc_tpb_read_committed, isc_tpb_rec_version],
-    ISOLATION_READ_COMMITED             = [isc_tpb_version3, isc_tpb_write, isc_tpb_wait, isc_tpb_read_committed, isc_tpb_no_rec_version],
-    ISOLATION_REPEATABLE_READ           = [isc_tpb_version3, isc_tpb_write, isc_tpb_wait, isc_tpb_concurrency],
-    ISOLATION_SERIALIZABLE              = [isc_tpb_version3, isc_tpb_write, isc_tpb_wait, isc_tpb_consistency],
-    ISOLATION_READ_COMMITED_READ_ONLY   = [isc_tpb_version3, isc_tpb_read, isc_tpb_wait, isc_tpb_read_committed, isc_tpb_no_rec_version];
+    ISOLATION_READ_UNCOMMITTED          = [ISC_TPB.version3, ISC_TPB.write, ISC_TPB.wait, ISC_TPB.read_committed, ISC_TPB.rec_version],
+    ISOLATION_READ_COMMITED             = [ISC_TPB.version3, ISC_TPB.write, ISC_TPB.wait, ISC_TPB.read_committed, ISC_TPB.no_rec_version],
+    ISOLATION_REPEATABLE_READ           = [ISC_TPB.version3, ISC_TPB.write, ISC_TPB.wait, ISC_TPB.concurrency],
+    ISOLATION_SERIALIZABLE              = [ISC_TPB.version3, ISC_TPB.write, ISC_TPB.wait, ISC_TPB.consistency],
+    ISOLATION_READ_COMMITED_READ_ONLY   = [ISC_TPB.version3, ISC_TPB.read, ISC_TPB.wait, ISC_TPB.read_committed, ISC_TPB.no_rec_version];
 
 const
     DEFAULT_HOST = '127.0.0.1',

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ var
     BlrReader = serialize.BlrReader,
     XdrWriter = serialize.XdrWriter,
     BlrWriter = serialize.BlrWriter,
-    messages = require('./messages.js')
+    messages = require('./messages.js'),
+    GDSError = require('./errors.js').GDSError
 
 if (typeof(setImmediate) === 'undefined') {
     global.setImmediate = function(cb) {
@@ -1371,7 +1372,7 @@ function doCallback(obj, callback) {
     }
 
     if (isError(obj)) {
-        callback(new Error(obj.message));
+        callback(new GDSError(obj));
         return;
     }
 


### PR DESCRIPTION
Hi.
When capturing errors from firebird you might want to check integer error code for doing various actions, instead of checking error messages. 
For example: if code === 335544517, then it was exception throwed from PSQL code.